### PR TITLE
Fixes grabbing longer list and dropping subtasks without parent in API response

### DIFF
--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -3,7 +3,7 @@ Module.register("MMM-GoogleTasks", {
 	defaults: {
 
 		listID: "", // List ID (see authenticate.js)
-		maxResults: 10,		
+		taskCount: 10,		
 		dateFormat: "MMM Do", 	// Format to display dates (moment.js formats)
 		updateInterval: 100000, // Time between content updates (millisconds)
 		animationSpeed: 2000, 	// Speed of the update animation (milliseconds)
@@ -193,14 +193,13 @@ Module.register("MMM-GoogleTasks", {
 		groupSubTasks = this.config.groupSubTasks;
 
 	        for (i = 0; i < taskList.length; i++) {
-
         		// if groupsubtasks is true, and it doesn't have parents, display outerloop
             		// if groupsubtasks is false, regardless, display outerloop
             		// otherwise, don't display outer loop, means we're grouping by subtask and this one has parents (is child)
             		// ignore items that have parents; they'll get displayed in the subloop underneath their parents.
 
             		if (!groupSubTasks || (!taskList[i].parent && groupSubTasks)) {
-                		task_count++;
+				task_count++;
                 		// Display the top level tasks
 
 				item = taskList[i];
@@ -277,9 +276,13 @@ Module.register("MMM-GoogleTasks", {
 
 	                	                wrapper.appendChild(titleWrapper);
         		                        wrapper.appendChild(dateWrapper);
+
+						if (++task_count >= this.config.taskCount){ break; }
                     			}
                 		}
+				if (task_count >= this.config.taskCount){ break; }
             		}
+			
         	}
 
 		return wrapper;

--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -199,7 +199,6 @@ Module.register("MMM-GoogleTasks", {
             		// ignore items that have parents; they'll get displayed in the subloop underneath their parents.
 
             		if (!groupSubTasks || (!taskList[i].parent && groupSubTasks)) {
-				task_count++;
                 		// Display the top level tasks
 
 				item = taskList[i];
@@ -234,6 +233,8 @@ Module.register("MMM-GoogleTasks", {
 
                         	wrapper.appendChild(titleWrapper);
                         	wrapper.appendChild(dateWrapper);
+				
+				if (++task_count >= this.config.taskCount){ break; }
 
                 		// Display subtasks under this task; they will be internally also sorted according to the overall sort order
                 		// This mechanism works because there can be only one level of subtasks within Google Tasks
@@ -280,9 +281,7 @@ Module.register("MMM-GoogleTasks", {
 						if (++task_count >= this.config.taskCount){ break; }
                     			}
                 		}
-				if (task_count >= this.config.taskCount){ break; }
             		}
-			
         	}
 
 		return wrapper;

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ var config = {
 |------------------------ |--------------
 | `listID`                | *Required* - List ID printed from authenticate.js (see installation)
 | `taskCount`             | *Optional* - Number of list items to show <br><br> **Default value:** `10`
-| `showCompleted`         | *Optional* - Show completed task items <br><br> **Possible values:** `true`  `false` <br> **Default value:** `false`
 | `dateFormat`            | *Optional* - Format to use for due date <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
 | `updateInterval`        | *Optional* - Interval at which content updates (Milliseconds) <br><br> **Possible values:** `2000` - `86400000` (Tasks API has default maximum of 50,000 calls per day.) <br> **Default value:** `10000` (10 seconds)
 | `animationSpeed`        | Speed of the update animation. (Milliseconds) <br><br> **Possible values:** `0` - `5000` <br> **Default value:** `2000` (2 seconds)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var config = {
 | Option                  | Details
 |------------------------ |--------------
 | `listID`                | *Required* - List ID printed from authenticate.js (see installation)
-| `maxResults`            | *Optional* - Max number of list items to retrieve. <br><br> **Possible values:** `0` - `100` <br> **Default value:** `10`
+| `taskCount`             | *Optional* - Number of list items to show <br><br> **Default value:** `10`
 | `showCompleted`         | *Optional* - Show completed task items <br><br> **Possible values:** `true`  `false` <br> **Default value:** `false`
 | `dateFormat`            | *Optional* - Format to use for due date <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
 | `updateInterval`        | *Optional* - Interval at which content updates (Milliseconds) <br><br> **Possible values:** `2000` - `86400000` (Tasks API has default maximum of 50,000 calls per day.) <br> **Default value:** `10000` (10 seconds)

--- a/node_helper.js
+++ b/node_helper.js
@@ -61,7 +61,7 @@ module.exports = NodeHelper.create({
     },
 
     buildList: function(config, listItems, pageToken){
-	var self = this;
+	let self = this;
 
         if(!self.service) {
             console.log("Refresh required"); 
@@ -81,20 +81,20 @@ module.exports = NodeHelper.create({
 		// Continue to fetch the next page as long as the Google API says there is one
 		self.buildList(config, listItems, nextPageToken);
 	    } else {
-		var payload = {id: config.listID, items: listItems};
+		let payload = {id: config.listID, items: listItems};
 		self.sendSocketNotification("UPDATE_DATA", payload);
 	    }
 	}).catch(err => {
-		var payload = {code: err.code, message: err.message, details: err.details};
+		let payload = {code: err.code, message: err.message, details: err.details};
 		self.sendSocketNotification("TASKS_API_ERROR", payload);
 		return console.error('The API returned an error: ' + err);
 	});
     },
 
     getList: function(config) {
-        var self = this;
-	var pageToken;
-	var listItems = [];
+        let self = this;
+	let pageToken;
+	let listItems = [];
 	// Going to recursively build the listItems
 	self.buildList(config, listItems, pageToken);
     },

--- a/node_helper.js
+++ b/node_helper.js
@@ -78,6 +78,7 @@ module.exports = NodeHelper.create({
 	    let nextPageToken = res.data.nextPageToken;
 	    listItems = listItems.concat(res.data.items);
 	    if (nextPageToken){
+		// Continue to fetch the next page as long as the Google API says there is one
 		self.buildList(config, listItems, nextPageToken);
 	    } else {
 		var payload = {id: config.listID, items: listItems};
@@ -94,6 +95,7 @@ module.exports = NodeHelper.create({
         var self = this;
 	var pageToken;
 	var listItems = [];
+	// Going to recursively build the listItems
 	self.buildList(config, listItems, pageToken);
     },
 });


### PR DESCRIPTION
To some, `maxResults` almost appears to mean "number of items to grab" - this is only partially correct as `maxResults` is defined in the Google API as the "maximum number of task lists returned on one page". MMM-GoogleTasks is only grabbing one request, so one page - that's it. If the list you are requesting to grab is larger than one page as defined by `maxResults`, it could mean that the Google API returns subtasks that don't have their resulting parent in the one request MMM-GoogleTasks is making and is then not displayed at all. This update grabs **ALL** list items across _n_ pages, then filters them down to `taskCount` size to display. Sure this could result in more API request to grab all tasks, but no data is dropped as a result.